### PR TITLE
feat(langchain): add langchain agent example

### DIFF
--- a/langchain_example/README.md
+++ b/langchain_example/README.md
@@ -1,21 +1,68 @@
 ﻿# LangChain Example
 
+
 ## 1. 目标
 本示例演示如何把 MagicSkills 的 skill_tool 接入 LangChain agent，并生成两份完整日志：
 
 - log1.json：不停读文档场景（偏知识学习）
 - log2.json：执行场景（把 C 代码转换为 AST）
 
-日志会保留 agent 每一步输出（包含中间 tool 调用与最终回答），格式参考 langgraph_example/log1.json 与 langgraph_example/log2.json。
+日志会保留 agent 每一步输出（包含中间 tool 调用与最终回答），格式参考 langchain_example/log1.json 与 langchain_example/log2.json。
 
-## 2. 环境准备
-在项目根目录执行：
+本示例还展示了 MagicSkills 多 agent 管理的核心特性：为不同 agent 创建独立的 skills 集合，每个 agent 只暴露它所需的工具。
+
+
+## 2. 安装 magicskills
 
 ```bash
-uv --version
+git clone https://github.com/Narwhal-Lab/MagicSkills.git
+cd MagicSkills
+pip install -e .
 ```
 
-确保根目录有 .env（可从 .env.example 复制）：
+
+## 3. 安装 skill
+
+以下演示两种安装方式，若 skill 已安装可跳过对应命令。
+
+### 方式一：从本地安装（项目内置模板）
+
+```bash
+magicskills install skill_template -t ~/allskills
+```
+
+### 方式二：从 GitHub 安装
+
+```bash
+magicskills install Narwhal-Lab/MagicSkills -t ~/allskills
+```
+
+> `-t ~/allskills` 指定安装目录。
+
+
+## 4. 创建 skills
+
+本示例创建两个 skills 集合，分别对应两个 agent，每个 agent 拥有不同的工具组合：
+
+```bash
+magicskills createskills langchain_agent1_skills --skill-list c_2_ast pdf --agent-md-path ./AGENTS.md
+magicskills createskills langchain_agent2_skills --skill-list c_2_ast docx --agent-md-path ./AGENTS.md
+```
+
+- **langchain_agent1_skills**：`c_2_ast` + `pdf`，用于 log1 场景（知识阅读 agent）
+- **langchain_agent2_skills**：`c_2_ast` + `docx`，用于 log2 场景（代码执行 agent）
+
+
+## 5. 生成 AGENTS.md
+
+```bash
+magicskills syncskills langchain_agent1_skills --output ./AGENTS.md -y
+```
+
+
+## 6. 环境准备
+
+确保根目录有 `.env`（可从 `.env.example` 复制）：
 
 ```bash
 cp .env.example .env
@@ -23,25 +70,63 @@ cp .env.example .env
 
 并填写：
 
-- OPENAI_BASE_URL
-- OPENAI_API_KEY
-- OPENAI_MODEL
+- `OPENAI_BASE_URL`
+- `OPENAI_API_KEY`
+- `OPENAI_MODEL`
 
-## 3. 运行方式
+
+## 7. 安装依赖并运行
+
+```bash
+pip install -r langchain_example/requirements.txt
+```
+
 在项目根目录执行：
 
 ```bash
-uv run --with langchain-openai --with python-dotenv python langchain_example/model.py --scenario all
+python langchain_example/model.py --scenario all
 ```
 
 可选：只跑单个场景
 
 ```bash
-uv run --with langchain-openai --with python-dotenv python langchain_example/model.py --scenario read
-uv run --with langchain-openai --with python-dotenv python langchain_example/model.py --scenario exec
+python langchain_example/model.py --scenario read
+python langchain_example/model.py --scenario exec
 ```
 
-## 4. 产物说明
+
+## 8. 两个场景的 prompt
+
+### 场景一：了解更多 AST 知识（log1.json）
+
+输入 prompt：
+
+```
+我想了解更多 AST 知识。
+```
+
+agent 会依次执行：`listskill` → `readskill`（读取 SKILL.md）→ `readskill`（读取 reference.md），通过多步文档阅读获取 AST 相关知识。
+
+### 场景二：转换一段代码为 AST（log2.json）
+
+输入 prompt：
+
+````
+请将下面这段 C 代码转换为 AST
+```c
+#include <stdio.h>
+
+int main() {
+    puts("Hello from agent");
+    return 0;
+}
+```
+````
+
+agent 会依次执行：`listskill` → `readskill`（读取 SKILL.md）→ `execskill`（运行转换脚本），产出 AST 结果。
+
+
+## 9. 产物说明
 运行完成后，本目录会生成：
 
 - log1.json
@@ -52,7 +137,9 @@ uv run --with langchain-openai --with python-dotenv python langchain_example/mod
 - log1.json 中是否出现多步文档阅读行为（围绕 AST 相关 skill）
 - log2.json 中是否出现执行步骤并产出 AST 结果
 
-## 5. 常见问题
-- 如果报认证错误：检查 .env 中的 key、base_url、model 是否可用。
+
+## 10. 常见问题
+- 如果报 `skills collection(s) not found`：请先按第 4 步执行 `createskills` 命令。
+- 如果报认证错误：检查 `.env` 中的 key、base_url、model 是否可用。
 - 如果报网络错误：确认当前环境可访问配置的模型服务。
 - 如果日志为空：重跑命令并查看终端输出中的异常栈信息。

--- a/langchain_example/log1.json
+++ b/langchain_example/log1.json
@@ -1,9 +1,42 @@
 [AI] content=
-  -> tool_call: skill_tool({'action': 'listskill'})
-  <- result: {"ok": true, "action": "listskill", "result": "1. name: c_2_ast\n   description: Parse C source code into an Abstract Syntax Tree (AST). Use when analyzing C programs, understanding code structure, performing static analysis, or preparing code for further program analysis (e.g., CFG, DFG, vulnerabil
-[AI] content=我看到有一个C语言AST解析的技能。让我先查看这个技能的详细信息：
-  -> tool_call: skill_tool({'action': 'readskill', 'arg': 'D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\SKILL.md'})
-  <- result: {"ok": true, "action": "readskill", "result": "---\nname: c-to-ast\ndescription: Parse C source code into an Abstract Syntax Tree (AST). Use when analyzing C programs, understanding code structure, performing static analysis, or preparing code for further program analysis (e.g., CFG, DFG, vulnerabil
+  -> tool_call: skill_tool({'action': 'listskill', 'arg': 'AST'})
+  <- result: {"ok": true, "action": "listskill", "result": [{"name": "c_2_ast", "description": "Parse C source code into an Abstract Syntax Tree (AST). Use when analyzing C programs, understanding code structure, performing static analysis, or preparing code for further program analysis (e.g., CFG, DFG, vulnerab
 [AI] content=
+  -> tool_call: skill_tool({'action': 'readskill', 'arg': 'C:\\Users\\Palin\\allskills\\c_2_ast\\SKILL.md'})
+  <- result: {"ok": true, "action": "readskill", "result": "---\nname: c-to-ast\ndescription: Parse C source code into an Abstract Syntax Tree (AST). Use when analyzing C programs, understanding code structure, performing static analysis, or preparing code for further program analysis (e.g., CFG, DFG, vulnerabil
+[AI] content=你对 AST（抽象语法树）感兴趣，这是一个非常重要的概念，尤其在编译器、程序分析和安全研究中。根据我查到的资料，目前有一个专门用于将 **C 语言源代码** 转换为 AST 的工具。
+
+这个工具的核心功能是：
+- **解析 C 代码**：将 `.c` 文件或一段 C 代码字符串，转换成一个结构化的树形表示。
+- **应用场景**：理解代码结构、进行静态分析、漏洞检测、或为更深入的程序分析（如控制流
 
 === final ===
+你对 AST（抽象语法树）感兴趣，这是一个非常重要的概念，尤其在编译器、程序分析和安全研究中。根据我查到的资料，目前有一个专门用于将 **C 语言源代码** 转换为 AST 的工具。
+
+这个工具的核心功能是：
+- **解析 C 代码**：将 `.c` 文件或一段 C 代码字符串，转换成一个结构化的树形表示。
+- **应用场景**：理解代码结构、进行静态分析、漏洞检测、或为更深入的程序分析（如控制流图 CFG）做准备。
+
+**AST 长什么样？**
+它是一个文本形式的树状结构，例如：
+```
+FileAST:
+  FuncDef:
+    Decl: main
+    FuncDecl:
+      TypeDecl:
+        IdentifierType: ['int']
+    Compound:
+      FuncCall:
+        ID: puts
+        ExprList:
+          Constant: string, "Hello"
+      Return:
+        Constant: int, 0
+```
+这个例子清晰地展示了 `main` 函数的结构，包括它的返回类型、函数调用 (`puts`) 和返回语句。
+
+**如果你想亲自尝试：**
+你可以提供一个 C 语言源文件的路径，或者直接粘贴一段 C 代码，我可以帮你把它转换成 AST。
+
+你是否有具体的 C 代码想要分析呢？

--- a/langchain_example/log2.json
+++ b/langchain_example/log2.json
@@ -1,60 +1,93 @@
 [AI] content=
-  -> tool_call: skill_tool({'action': 'listskill'})
-  <- result: {"ok": true, "action": "listskill", "result": "1. name: c_2_ast\n   description: Parse C source code into an Abstract Syntax Tree (AST). Use when analyzing C programs, understanding code structure, performing static analysis, or preparing code for further program analysis (e.g., CFG, DFG, vulnerabil
+  -> tool_call: skill_tool({'action': 'listskill', 'arg': 'ast'})
+  <- result: {"ok": true, "action": "listskill", "result": [{"name": "c_2_ast", "description": "Parse C source code into an Abstract Syntax Tree (AST). Use when analyzing C programs, understanding code structure, performing static analysis, or preparing code for further program analysis (e.g., CFG, DFG, vulnerab
 [AI] content=
-  -> tool_call: skill_tool({'action': 'readskill', 'arg': 'D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\SKILL.md'})
+  -> tool_call: skill_tool({'action': 'readskill', 'arg': 'C:\\Users\\Palin\\allskills\\c_2_ast\\SKILL.md'})
   <- result: {"ok": true, "action": "readskill", "result": "---\nname: c-to-ast\ndescription: Parse C source code into an Abstract Syntax Tree (AST). Use when analyzing C programs, understanding code structure, performing static analysis, or preparing code for further program analysis (e.g., CFG, DFG, vulnerabil
 [AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast" && ls -la'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\" && ls -la", "returncode": 1, "stdout": "", "stderr": "'ls' 不是内部或外部命令，也不是可运行的程序\n或批处理文件。\n"}}
+  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd C:\\Users\\Palin\\allskills\\c_2_ast\\scripts && python3 save_c.py --input "#include <stdio.h>\\n\\nint main() {\\n    puts(\\"Hello from agent\\");\\n    return 0;\\n}" --output . --filename temp.c'})
+  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd C:\\Users\\Palin\\allskills\\c_2_ast\\scripts && python3 save_c.py --input \"#include <stdio.h>\\n\\nint main() {\\n    puts(\\\"Hello from agent\\\");\\n    return 0;\\n}\" --output . --filename temp.c", "returncode": 2, "stdout": "", "s
 [AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast" && dir'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\" && dir", "returncode": 0, "stdout": " 驱动器 D 中的卷是 Data\n 卷的序列号是 FC7D-E567\n\n D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast 的目录\n\n2026/03/09  22:35    <DIR>          .\n2026/
+  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'ls C:\\Users\\Palin\\allskills\\c_2_ast\\scripts'})
+  <- result: {"ok": true, "action": "execskill", "result": {"command": "ls C:\\Users\\Palin\\allskills\\c_2_ast\\scripts", "returncode": 0, "stdout": "c_2_ast.py\noutput.c\nsave_c.py\nsource.c\ntemp.c\ntest.c\ntest_input.c\n", "stderr": ""}}
 [AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && dir'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && dir", "returncode": 0, "stdout": " 驱动器 D 中的卷是 Data\n 卷的序列号是 FC7D-E567\n\n D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts 的目录\n\n2026/03/09  22:35    <DIR>
+  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd C:\\Users\\Palin\\allskills\\c_2_ast\\scripts && python save_c.py --input "#include <stdio.h>\\n\\nint main() {\\n    puts(\\"Hello from agent\\");\\n    return 0;\\n}" --output . --filename temp.c'})
+  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd C:\\Users\\Palin\\allskills\\c_2_ast\\scripts && python save_c.py --input \"#include <stdio.h>\\n\\nint main() {\\n    puts(\\\"Hello from agent\\\");\\n    return 0;\\n}\" --output . --filename temp.c", "returncode": 2, "stdout": "", "st
 [AI] content=
-  -> tool_call: skill_tool({'action': 'readskill', 'arg': 'D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\\save_c.py'})
-  <- result: {"ok": true, "action": "readskill", "result": "#!/usr/bin/env python3\nfrom __future__ import annotations\n\nimport argparse\nfrom pathlib import Path\nimport sys\n\n\ndef save_c_code(c_code: str, output_dir: Path, filename: str = \"output.c\") -> Path:\n    \"\"\"\n    Save a C source code string t
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && python save_c.py --input "#include <stdio.h>\n\nint main() {\n    puts(\\"Hello from agent\\");\n    return 0;\n}" --output . --filename input.c'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && python save_c.py --input \"#include <stdio.h>\n\nint main() {\n    puts(\\\"Hello from agent\\\");\n    return 0;\n}\" --output . --filename input.c", "returncode": 0, "
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && dir'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && dir", "returncode": 0, "stdout": " 驱动器 D 中的卷是 Data\n 卷的序列号是 FC7D-E567\n\n D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts 的目录\n\n2026/03/09  23:20    <DIR>
-[AI] content=
-  -> tool_call: skill_tool({'action': 'readskill', 'arg': 'D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\\c_2_ast.py'})
-  <- result: {"ok": true, "action": "readskill", "result": "#!/usr/bin/env python3\nfrom __future__ import annotations\n\nimport argparse\nimport sys\nimport tempfile\nfrom pathlib import Path\nfrom pycparser import parse_file, c_ast\n\n\n# =========================================================\n# 内置最小 fake l
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && python c_2_ast.py --input output.c'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && python c_2_ast.py --input output.c", "returncode": 1, "stdout": "", "stderr": "Traceback (most recent call last):\n  File \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'python -m pip install pycparser'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "python -m pip install pycparser", "returncode": 1, "stdout": "", "stderr": "D:\\uv_data\\cache\\builds-v0\\.tmpOQZuA6\\Scripts\\python.exe: No module named pip\n"}}
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'python -m ensurepip --upgrade'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "python -m ensurepip --upgrade", "returncode": 0, "stdout": "Looking in links: c:\\Users\\Palin\\AppData\\Local\\Temp\\tmpxnsorgx9\nProcessing c:\\users\\palin\\appdata\\local\\temp\\tmpxnsorgx9\\setuptools-79.0.1-py3-none-any.whl\nProcessing
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'python -m pip install pycparser'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "python -m pip install pycparser", "returncode": 0, "stdout": "Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple\nCollecting pycparser\n  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/0c/c3/44f3fbbfa403ea2a7c779186dc207726
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && python c_2_ast.py --input output.c'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && python c_2_ast.py --input output.c", "returncode": 0, "stdout": "FileAST: \n  Typedef: FILE, [], ['typedef']\n    TypeDecl: FILE, [], None\n      IdentifierType: ['int']
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && type output.c'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && type output.c", "returncode": 0, "stdout": "#include <stdio.h>\n", "stderr": ""}}
-[AI] content=I see the issue. The output.c file only contains the first line `#include <stdio.h>` and not the full C code. Let me check what happened and create a new file with the complete C code.
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && echo #include <stdio.h>\n\nint main() {\n    puts("Hello from agent");\n    return 0;\n} > complete.c'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && echo #include <stdio.h>\n\nint main() {\n    puts(\"Hello from agent\");\n    return 0;\n} > complete.c", "returncode": 1, "stdout": "", "stderr": "命令语法不正确。\n"}}
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && python -c "\nwith open(\'complete.c\', \'w\', encoding=\'utf-8\') as f:\n    f.write(\'#include <stdio.h>\\n\\nint main() {\\n    puts(\\"Hello from agent\\");\\n    return 0;\\n}\\n\')\nprint(\'File created\')\n"'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && python -c \"\nwith open('complete.c', 'w', encoding='utf-8') as f:\n    f.write('#include <stdio.h>\\n\\nint main() {\\n    puts(\\\"Hello from agent\\\");\\n    return 
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && type complete.c'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && type complete.c", "returncode": 1, "stdout": "", "stderr": "系统找不到指定的文件。\n"}}
-[AI] content=
-  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd "D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts" && dir'})
-  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd \"D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts\" && dir", "returncode": 0, "stdout": " 驱动器 D 中的卷是 Data\n 卷的序列号是 FC7D-E567\n\n D:\\大二项目\\MagicSkills2\\MagicSkills\\skills\\c_2_ast\\scripts 的目录\n\n2026/03/09  23:20    <DIR>
-[AI] content=
+  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'cd C:\\Users\\Palin\\allskills\\c_2_ast\\scripts && python c_2_ast.py --input temp.c'})
+  <- result: {"ok": true, "action": "execskill", "result": {"command": "cd C:\\Users\\Palin\\allskills\\c_2_ast\\scripts && python c_2_ast.py --input temp.c", "returncode": 2, "stdout": "", "stderr": "python: can't open file 'D:\\\\大二项目\\\\MagicSkill\\\\MagicSkills\\\\c_2_ast.py': [Errno 2] No such file or direc
+[AI] content=看起来在执行脚本时遇到了路径问题。让我尝试直接使用完整的路径来执行：
+
+
+  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'python C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\c_2_ast.py --input C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\temp.c'})
+  <- result: {"ok": true, "action": "execskill", "result": {"command": "python C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\c_2_ast.py --input C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\temp.c", "returncode": 0, "stdout": "FileAST: \n  Typedef: FILE, [], ['typedef']\n    TypeDecl: FILE, [], None\n      Ide
+[AI] content=我注意到在保存文件时出现了问题，导致C代码中包含了转义字符。让我重新创建一个正确的C文件：
+
+
+  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'echo #include ^<stdio.h^> > C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c && echo. >> C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c && echo int main^(^) { >> C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c && echo     puts^("Hello from agent"^); >> C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c && echo     return 0; >> C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c && echo } >> C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c'})
+  <- result: {"ok": true, "action": "execskill", "result": {"command": "echo #include ^<stdio.h^> > C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c && echo. >> C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c && echo int main^(^) { >> C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c && e
+[AI] content=现在让我使用正确的C文件来生成AST：
+
+
+  -> tool_call: skill_tool({'action': 'execskill', 'arg': 'python C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\c_2_ast.py --input C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c'})
+  <- result: {"ok": true, "action": "execskill", "result": {"command": "python C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\c_2_ast.py --input C:\\Users\\Palin\\allskills\\c_2_ast\\scripts\\correct.c", "returncode": 0, "stdout": "FileAST: \n  Typedef: FILE, [], ['typedef']\n    TypeDecl: FILE, [], None\n      
+[AI] content=成功！以下是您提供的C代码的抽象语法树（AST）：
+
+```
+FileAST: 
+  Typedef: FILE, [], ['typedef']
+    TypeDecl: FILE, [], None
+      IdentifierType: ['int']
+  Decl: printf, [], [], [], []
+    FuncDecl: 
+      ParamList: 
+   
 
 === final ===
+成功！以下是您提供的C代码的抽象语法树（AST）：
+
+```
+FileAST: 
+  Typedef: FILE, [], ['typedef']
+    TypeDecl: FILE, [], None
+      IdentifierType: ['int']
+  Decl: printf, [], [], [], []
+    FuncDecl: 
+      ParamList: 
+        Decl: fmt, ['const'], [], [], []
+          PtrDecl: []
+            TypeDecl: fmt, ['const'], None
+              IdentifierType: ['char']
+        EllipsisParam: 
+      TypeDecl: printf, [], None
+        IdentifierType: ['int']
+  Decl: puts, [], [], [], []
+    FuncDecl: 
+      ParamList: 
+        Decl: s, ['const'], [], [], []
+          PtrDecl: []
+            TypeDecl: s, ['const'], None
+              IdentifierType: ['char']
+      TypeDecl: puts, [], None
+        IdentifierType: ['int']
+  FuncDef: 
+    Decl: main, [], [], [], []
+      FuncDecl: 
+        TypeDecl: main, [], None
+          IdentifierType: ['int']
+    Compound: 
+      FuncCall: 
+        ID: puts
+        ExprList: 
+          Constant: string, "Hello from agent"
+      Return: 
+        Constant: int, 0
+```
+
+这个AST显示了C程序的完整结构：
+- 文件级别的声明（包括FILE类型定义和标准库函数printf、puts的声明）
+- main函数的定义，包含：
+  - 函数声明（返回int类型）
+  - 复合语句（函数体）
+  - puts函数调用，参数为字符串常量"Hello from agent"
+  - 返回语句，返回整数0

--- a/langchain_example/model.py
+++ b/langchain_example/model.py
@@ -1,8 +1,9 @@
-﻿"""LangChain tool-binding example — progressive skill disclosure.
+"""LangChain tool-binding example — progressive skill disclosure.
 
 Usage:
-    uv run --with langchain-openai --with python-dotenv \
-        python langchain_example/model.py --scenario all
+    # First follow README.md setup steps, then:
+    pip install -r langchain_example/requirements.txt
+    python langchain_example/model.py --scenario all
 
 Env vars (put in .env):
     OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL
@@ -30,19 +31,64 @@ from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 
-from magicskills import ALL_SKILLS, Skills
+from magicskills import REGISTRY
+from magicskills.type.skills import Skills
 
 load_dotenv()
 
-# ── 场景配置：log1=不停读 / log2=有执行 ─────────────────────────
-SCENARIOS: dict[str, tuple[str, str]] = {
+_SETUP_HINT = """\
+Please follow the README.md setup steps to create skills collections first:
+  magicskills createskills langchain_agent1_skills --skill-list c_2_ast pdf --agent-md-path ./AGENTS.md
+  magicskills createskills langchain_agent2_skills --skill-list c_2_ast docx --agent-md-path ./AGENTS.md
+"""
+
+
+# ── 1. Load skill collections from registry ────────────────────
+def _load_agent_skills() -> tuple[Skills, Skills]:
+    errors: list[str] = []
+    agent1_skills: Skills | None = None
+    agent2_skills: Skills | None = None
+
+    try:
+        agent1_skills = REGISTRY.get_skills("langchain_agent1_skills")
+    except KeyError:
+        errors.append("langchain_agent1_skills")
+
+    try:
+        agent2_skills = REGISTRY.get_skills("langchain_agent2_skills")
+    except KeyError:
+        errors.append("langchain_agent2_skills")
+
+    if errors:
+        print(f"Error: skills collection(s) not found: {errors}", file=sys.stderr)
+        print(_SETUP_HINT, file=sys.stderr)
+        sys.exit(1)
+
+    return agent1_skills, agent2_skills  # type: ignore[return-value]
+
+
+agent1_skills, agent2_skills = _load_agent_skills()
+
+
+# ── 2. Per-agent skill tool factory ────────────────────────────
+def _make_skill_tool(skills: Skills):
+    @tool("skill_tool", description=skills.tool_description)
+    def _skill_tool(action: str, arg: str = "") -> str:
+        return json.dumps(skills.skill_tool(action, arg), ensure_ascii=False)
+
+    return _skill_tool
+
+
+# ── 3. 场景配置 ─────────────────────────────────────────────────
+SCENARIOS: dict[str, tuple[str, str, Skills]] = {
     "read": (
         "log1.json",
-        "我想了解很多 AST 知识。",
+        "我想了解更多 AST 知识。",
+        agent1_skills,
     ),
     "exec": (
         "log2.json",
-        "Please help me convert the following C code into an AST.\n"
+        "请将下面这段 C 代码转换为 AST\n"
         "```c\n"
         "#include <stdio.h>\n\n"
         "int main() {\n"
@@ -50,34 +96,13 @@ SCENARIOS: dict[str, tuple[str, str]] = {
         "    return 0;\n"
         "}\n"
         "```",
+        agent2_skills,
     ),
 }
 
-# ── 1. 组装 Skills ─────────────────────────────────────────────
-def _resolve_required_skills() -> tuple[object, object]:
-    all_skills = ALL_SKILLS()
-    try:
-        return all_skills.get_skill("pdf"), all_skills.get_skill("c_2_ast")
-    except KeyError:
-        local_skills = Skills(paths=[ROOT / "skills"])
-        return local_skills.get_skill("pdf"), local_skills.get_skill("c_2_ast")
 
-
-skill_a, skill_b = _resolve_required_skills()
-
-my_skills = Skills(
-    name="langchain_skills",
-    skill_list=[skill_a, skill_b],
-)
-
-# ── 2. 包装为 LangChain tool ───────────────────────────────────
-@tool("skill_tool", description=my_skills.tool_description)
-def _skill_tool(action: str, arg: str = "") -> str:
-    return json.dumps(my_skills.skill_tool(action, arg), ensure_ascii=False)
-
-
-# ── 3. 多轮 tool-calling loop ─────────────────────────────────
-def run_once(prompt: str, log_name: str) -> None:
+# ── 4. 多轮 tool-calling loop ─────────────────────────────────
+def run_once(prompt: str, log_name: str, skills: Skills) -> None:
     llm = ChatOpenAI(
         model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
         temperature=0.0,
@@ -85,12 +110,13 @@ def run_once(prompt: str, log_name: str) -> None:
         api_key=os.getenv("OPENAI_API_KEY"),
         timeout=120,
     )
-    llm_with_tools = llm.bind_tools([_skill_tool])
+    skill_tool = _make_skill_tool(skills)
+    llm_with_tools = llm.bind_tools([skill_tool])
 
     messages: list = [("user", prompt)]
     log_lines: list[str] = []
     log_file = Path(__file__).parent / log_name
-    max_rounds = 15  # 防止 LLM 无限循环
+    max_rounds = 15
 
     try:
         for _round in range(max_rounds):
@@ -109,7 +135,7 @@ def run_once(prompt: str, log_name: str) -> None:
                 print(tc_info)
                 log_lines.append(tc_info)
 
-                tool_result = _skill_tool.invoke(tc["args"])
+                tool_result = skill_tool.invoke(tc["args"])
                 result_info = f"  <- result: {tool_result[:300]}"
                 print(result_info)
                 log_lines.append(result_info)
@@ -138,17 +164,10 @@ def main() -> None:
 
     targets = ["read", "exec"] if args.scenario == "all" else [args.scenario]
     for name in targets:
-        log_name, prompt = SCENARIOS[name]
+        log_name, prompt, skills = SCENARIOS[name]
         print(f"\n================ {name.upper()} ================\n")
-        run_once(prompt, log_name)
+        run_once(prompt, log_name, skills)
 
 
 if __name__ == "__main__":
     main()
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary

- Add `model.py` with two-agent pattern: `langchain_agent1_skills` (c_2_ast + pdf) for read scenario, `langchain_agent2_skills` (c_2_ast + docx) for exec scenario
- Add per-agent skill tool factory using LangChain's `@tool` decorator with `bind_tools`
- Add `README.md` with full setup steps, scenario descriptions, and troubleshooting
- Add `log1.json` (read scenario: listskill → readskill) and `log2.json` (exec scenario: listskill → readskill → execskill → AST output)

## Test plan

- [ ] log1.json shows multi-step document reading behavior (listskill → readskill around c_2_ast skill)
- [ ] log2.json shows execution step with AST result (execskill called and AST produced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)